### PR TITLE
Upgrade to Windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-2022]
         python-version:
           - name: pypy2
             toxenv: pypy2-build


### PR DESCRIPTION
windows-latest workflows will use windows-2022 soon. For more details see: actions/virtual-environments#4856

## Steps
- [x] Read actions/virtual-environments#4856
- [ ] Pin Windows-2022 (by merging)